### PR TITLE
Correct an article: *args is a tuple, not a list

### DIFF
--- a/python/packing-unpacking.md
+++ b/python/packing-unpacking.md
@@ -8,9 +8,9 @@ def __init__(self, *args, **kwargs):
     pass
 ```
 
-They perform an operation called 'packing'. True to it's name, what this does is *pack* all the arguments that this method call receives into one single variable, a list called `args`. You can use any variable name you want, of course, but `args` seems to be the most common and Pythonic way of doing things. 
+They perform an operation called 'packing'. True to it's name, what this does is *pack* all the arguments that this method call receives into one single variable, a tuple called `args`. You can use any variable name you want, of course, but `args` seems to be the most common and Pythonic way of doing things. 
 
-Once you have this 'packed' variable, you can do things with it that you would with a normal list. `args[0]` and `args[1]` would give you the first and second argument, respectively. You can also modify,  delete and re-arrange items in the list. 
+Once you have this 'packed' variable, you can do things with it that you would with a normal tuple. `args[0]` and `args[1]` would give you the first and second argument, respectively. If you convert the args tuple to a list you can also modify, delete and re-arrange items in it. 
 
 So how do you pass these packed arguments to another method? Here's where *unpacking* comes in to play:
 
@@ -33,6 +33,8 @@ def func1(x, y, z):
     print z  				
 
 def func2(*args):
+    # Convert args tuple to a list so we can modify it
+    args = list(args)
     args[0] = 'Hello'
     args[1] = 'awesome'
     func1(*args)


### PR DESCRIPTION
A function defined with *args receives the packed arguments as a tuple,
not a list. And hence to modify the args object you first have to
convert the tuple to a list:
    args = list(args)

I made corresponding corrections to the text and the example.

This is my first ever pull request on GitHub. Please let me know If I did something wrong.

Thanks,
Oleg
